### PR TITLE
build: do not treat erroneous compiler warning as error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(HEADER_LIB
 )
 
 add_library(flunder OBJECT ${SRC_LIB} ${HEADER_LIB})
+target_compile_options(flunder PUBLIC -Wno-error=restrict)
 
 set_property(TARGET flunder PROPERTY POSITION_INDEPENDENT_CODE 1)
 


### PR DESCRIPTION
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105651